### PR TITLE
Avoid negative number in OpenwaterEvaporaiton from lakes

### DIFF
--- a/src/lisflood/hydrological_modules/evapowater.py
+++ b/src/lisflood/hydrological_modules/evapowater.py
@@ -69,6 +69,8 @@ class evapowater(HydroModule):
             self.var.maxNoEva = int(loadmap('maxNoEva'))
             # all pits gets a high number
             # still to test if this works
+            self.var.downEva[self.var.downEva < 0] = maskinfo.info.mapC[0]
+            # This is to avoid downEva being negative
 
             # ldd only inside lakes for calculating evaporation
 


### PR DESCRIPTION
This is a minor fix to avoid negative numbers in one of the variables in evaporation from lakes module.